### PR TITLE
crashFix

### DIFF
--- a/components/SalesCallTranscriber.tsx
+++ b/components/SalesCallTranscriber.tsx
@@ -457,7 +457,7 @@ export default function SalesCallTranscriber() {
             </div>
           </CardHeader>
 
-          <CardContent className="p-4 flex-1 overflow-hidden flex flex-col">
+          <CardContent className="p-4 flex-1 overflow-hidden flex flex-col min-h-0">
             <Tabs defaultValue="form" className="w-full h-full flex flex-col">
               <TabsList className="grid w-full grid-cols-4 mb-4 bg-slate-100 p-1 rounded-lg h-9">
                 <TabsTrigger

--- a/components/sales-call/LeadForm.tsx
+++ b/components/sales-call/LeadForm.tsx
@@ -74,14 +74,15 @@ export function LeadForm({ resetTrigger, inboundPhone }: LeadFormProps) {
   const canAddMoreContacts = additionalContacts.length < MAX_ADDITIONAL_CONTACTS;
 
   return (
-    <div className="lg:flex-[2] space-y-0 px-0.75 py-0.75 overflow-y-auto h-relative">
+    <div className="lg:flex-[2] flex flex-col overflow-y-auto h-relative p-1 m-1">
+      <div className="space-y-0">
       {/* INTRO Section */}
-      <div className="mb-0">
+      <div className="mb-0 px-4">
         <span className="inline-block bg-white border-2 border-b-0 border-black px-3.5 py-1.5 shadow-sm shadow-black text-md font-bold rounded-t-md">
           INTRO
         </span>
       </div>
-      <div className="bg-white border-2 border-black rounded-b-lg rounded-tr-lg p-4 shadow-sm shadow-black">
+      <div className="bg-white border-2 border-black rounded-b-lg rounded-tr-lg p-4 shadow-sm shadow-black mx-4">
         <div className="space-y-3">
           {/* Name and What do you want to advertise */}
           <div className="flex gap-8">
@@ -193,23 +194,33 @@ export function LeadForm({ resetTrigger, inboundPhone }: LeadFormProps) {
       </div>
 
       {/* Lead Type Bar */}
-      <div className="bg-gray-300 border-2 border-black shadow-sm shadow-black rounded-lg p-3.5 my-5 ml-35 -mb-7">
-        <div className="flex items-center justify-between">
-          <LeadTypeButtonGroup />
-          <div className="flex items-center gap-2">
-            <Label className="text-md font-bold whitespace-nowrap">Ballpark:</Label>
-            <BallparkInput />
+      <div className="flex gap-8 my-5 -mb-7 px-4">
+        {/* Left spacer - matches Name field width */}
+        <div className="w-60"></div>
+
+        {/* Right side - matches "What do you want to advertise" section */}
+        <div className="flex-1 bg-gray-300 border-2 border-black shadow-sm shadow-black rounded-lg p-3.5">
+          <div className="flex items-center gap-4">
+            {/* Left: Lead Type Buttons - takes up flex space */}
+            <div className="flex-1 min-w-0">
+              <LeadTypeButtonGroup />
+            </div>
+            {/* Right: Ballpark section - fixed width based on content */}
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <Label className="text-md font-bold whitespace-nowrap">Ballpark:</Label>
+              <BallparkInput />
+            </div>
           </div>
         </div>
       </div>
 
       {/* PROPOSAL Section */}
-      <div className="mb-0 mt-3.5">
+      <div className="mb-0 mt-3.5 px-4">
         <span className="inline-block bg-white border-2 border-b-0 border-black shadow-sm shadow-black px-3.5 py-1.5 text-md font-bold rounded-t-md">
           PROPOSAL
         </span>
       </div>
-      <div className="bg-white border-2 border-black shadow-black rounded-b-lg rounded-tr-lg p-4 shadow-sm">
+      <div className="bg-white border-2 border-black shadow-black rounded-b-lg rounded-tr-lg p-4 shadow-sm mx-4">
         <div className="flex gap-5 h-full">
           {/* Left: Purpose Recap */}
           <div className="flex-1">
@@ -262,15 +273,15 @@ export function LeadForm({ resetTrigger, inboundPhone }: LeadFormProps) {
             </div>
 
             {/* Duration and Are you interested in */}
-            <div className="flex gap-4 flex-1">
-              {/* Duration */}
-              <div className="flex-2 flex flex-col">
+            <div className="flex gap-5 flex-1">
+              {/* Duration - matches City/State/Start column width */}
+              <div className="flex-[3] flex flex-col">
                 <Label className="text-blue-600 font-bold text-md mb-1 block">Duration</Label>
                 <DurationButtonGroup marketIndex={activeMarketIndex} />
               </div>
 
-              {/* Are you interested in */}
-              <div className="flex-1 mr-11">
+              {/* Are you interested in - matches Area column width */}
+              <div className="flex-[3] flex flex-col items-center">
                 <Label className="text-blue-600 text-center font-bold text-md mb-1 block">
                   Are you interested in?
                 </Label>
@@ -282,52 +293,63 @@ export function LeadForm({ resetTrigger, inboundPhone }: LeadFormProps) {
       </div>
 
       {/* Market Tabs */}
-      <div className="flex flex-wrap gap-1 mt-0 ml-172">
-        <button
-          onClick={() => setActiveMarketIndex(0)}
-          className={`inline-block border-2 ${
-            activeMarketIndex === 0 ? 'border-t-0 rounded-b-md' : 'bg-gray-300 text-gray-400 border-t-0 rounded-b-md'
-          } border-black shadow-sm shadow-black px-3.5 py-1.5 text-sm font-bold`}
-        >
-          Mkt #1
-        </button>
-        {additionalMarkets.map((_, index) => (
-          <button
-            key={index + 1}
-            onClick={() => setActiveMarketIndex(index + 1)}
-            className={`inline-block border-2 ${
-              activeMarketIndex === index + 1 ? 'border-t-0 rounded-b-md' : 'bg-gray-300 text-gray-400 border-t-0 rounded-b-md'
-            } border-black shadow-sm shadow-black px-3.5 py-1.5 text-sm font-bold relative group`}
-          >
-            <span>Mkt #{index + 2}</span>
-            <span
-              onClick={(e) => {
-                e.stopPropagation();
-                removeMarket(index + 1);
-              }}
-              className="ml-1.5 text-red-600 hover:text-red-800 cursor-pointer"
+      <div className="flex gap-5 mt-0 px-4">
+        {/* Left spacer - matches Purpose Recap width */}
+        <div className="flex-1"></div>
+
+        {/* Right side - matches Location & Duration width with nested structure */}
+        <div className="flex-1 flex gap-5">
+          {/* Tabs container - matches Duration position (flex-[3]) */}
+          <div className="flex-[3] flex flex-wrap gap-0.5 sm:gap-1 lg:gap-2">
+            <button
+              onClick={() => setActiveMarketIndex(0)}
+              className={`inline-block border-2 ${
+                activeMarketIndex === 0 ? 'border-t-0 rounded-b-md' : 'bg-gray-300 text-gray-400 border-t-0 rounded-b-md'
+              } border-black shadow-sm shadow-black px-1.5 py-0.5 sm:px-2.5 sm:py-1 lg:px-3.5 lg:py-1.5 text-[10px] sm:text-xs lg:text-sm font-bold`}
             >
-              ×
-            </span>
-          </button>
-        ))}
-        {canAddMoreMarkets && (
-          <button
-            onClick={addMarket}
-            className="inline-block text-gray-400 hover:text-black px-3.5 py-1.5 text-sm font-bold rounded-b-md transition-colors"
-          >
-            + Market
-          </button>
-        )}
+              Mkt #1
+            </button>
+            {additionalMarkets.map((_, index) => (
+              <button
+                key={index + 1}
+                onClick={() => setActiveMarketIndex(index + 1)}
+                className={`inline-block border-2 ${
+                  activeMarketIndex === index + 1 ? 'border-t-0 rounded-b-md' : 'bg-gray-300 text-gray-400 border-t-0 rounded-b-md'
+                } border-black shadow-sm shadow-black px-1.5 py-0.5 sm:px-2.5 sm:py-1 lg:px-3.5 lg:py-1.5 text-[10px] sm:text-xs lg:text-sm font-bold relative group`}
+              >
+                <span>Mkt #{index + 2}</span>
+                <span
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    removeMarket(index + 1);
+                  }}
+                  className="ml-1 sm:ml-1.5 text-red-600 hover:text-red-800 cursor-pointer"
+                >
+                  ×
+                </span>
+              </button>
+            ))}
+            {canAddMoreMarkets && (
+              <button
+                onClick={addMarket}
+                className="inline-block text-gray-400 hover:text-black px-1.5 py-0.5 sm:px-2.5 sm:py-1 lg:px-3.5 lg:py-1.5 text-[10px] sm:text-xs lg:text-sm font-bold rounded-b-md transition-colors"
+              >
+                + Market
+              </button>
+            )}
+          </div>
+          {/* Right spacer - matches "Are you interested in" position (flex-[3] mr-11) */}
+          <div className="flex-[3] mr-11"></div>
+        </div>
       </div>
 
       {/* Contact Tabs */}
-      <div className="flex flex-wrap gap-1 mt-2">
+      <div className="flex flex-wrap gap-0.5 sm:gap-1 lg:gap-2 mt-2 px-4">
         <button
           onClick={() => setActiveContactIndex(0)}
           className={`inline-block border-2 ${
             activeContactIndex === 0 ? 'border-b-0 rounded-t-md bg-gray-300' : 'bg-white text-gray-400 border-b-0 rounded-t-md'
-          } border-black shadow-sm shadow-black px-3.5 py-1.5 text-md font-bold`}
+          } border-black shadow-sm shadow-black px-1.5 py-0.5 sm:px-2.5 sm:py-1 lg:px-3.5 lg:py-1.5 text-[10px] sm:text-xs lg:text-md font-bold`}
         >
           CONTACT INFO
         </button>
@@ -337,7 +359,7 @@ export function LeadForm({ resetTrigger, inboundPhone }: LeadFormProps) {
             onClick={() => setActiveContactIndex(index + 1)}
             className={`inline-block border-2 ${
               activeContactIndex === index + 1 ? 'border-b-0 rounded-t-md bg-gray-300' : 'bg-white text-gray-400 border-b-0 rounded-t-md'
-            } border-black shadow-sm shadow-black px-3.5 py-1.5 text-md font-bold relative group`}
+            } border-black shadow-sm shadow-black px-1.5 py-0.5 sm:px-2.5 sm:py-1 lg:px-3.5 lg:py-1.5 text-[10px] sm:text-xs lg:text-md font-bold relative group`}
           >
             <span>CONTACT #{index + 2}</span>
             <span
@@ -345,7 +367,7 @@ export function LeadForm({ resetTrigger, inboundPhone }: LeadFormProps) {
                 e.stopPropagation();
                 removeContact(index + 1);
               }}
-              className="ml-1.5 text-red-600 hover:text-red-800 cursor-pointer"
+              className="ml-1 sm:ml-1.5 text-red-600 hover:text-red-800 cursor-pointer"
             >
               ×
             </span>
@@ -354,7 +376,7 @@ export function LeadForm({ resetTrigger, inboundPhone }: LeadFormProps) {
         {canAddMoreContacts && (
           <button
             onClick={addContact}
-            className="inline-block text-gray-400 hover:text-black px-3.5 py-1.5 text-sm font-bold rounded-t-md transition-colors"
+            className="inline-block text-gray-400 hover:text-black px-1.5 py-0.5 sm:px-2.5 sm:py-1 lg:px-3.5 lg:py-1.5 text-[10px] sm:text-xs lg:text-sm font-bold rounded-t-md transition-colors"
           >
             + Contact
           </button>
@@ -362,7 +384,7 @@ export function LeadForm({ resetTrigger, inboundPhone }: LeadFormProps) {
       </div>
 
       {/* Active Contact */}
-      <div className="bg-gray-300 border-2 border-black shadow-black rounded-b-lg rounded-tr-lg p-4 shadow-sm">
+      <div className="bg-gray-300 border-2 border-black shadow-black rounded-b-lg rounded-tr-lg p-4 shadow-sm mx-4">
         <div className="space-y-3">
           {/* Name, Position, Phone, Email */}
           <div className="grid grid-cols-4 gap-2.5">
@@ -402,6 +424,7 @@ export function LeadForm({ resetTrigger, inboundPhone }: LeadFormProps) {
             </div>
           </div>
         </div>
+      </div>
       </div>
     </div>
   );

--- a/components/sales-call/PricingPanel.tsx
+++ b/components/sales-call/PricingPanel.tsx
@@ -19,7 +19,7 @@ interface PricingPanelProps {
 
 interface PricingCard {
   market: string;
-  type: 'market-range' | 'general-range' | 'avg-views';
+  type: 'market-range' | 'general-range' | 'avg-views' | 'four-week-only';
   label: string;
   data: string[];
   note?: string;
@@ -237,19 +237,44 @@ export function PricingPanel({
     const marketRangeMatch = contextToUse.match(/Market\s*Range:\s*([^\n.]+)/i);
     const hasGeneralPricing = /General\s*Pricing:/i.test(contextToUse);
     
-    // PRIORITY 1: BLUE - has Average Daily Views
-    if (avgViewsMatch?.[1]) {
+    // Extract market name from context (e.g., "Market: Phoenix" or "Market Name: Phx")
+    const marketNameMatch = contextToUse.match(/Market(?:\s*Name)?:\s*([^,\n]+)/i);
+    const dbMarketName = marketNameMatch?.[1]?.trim() || '';
+    
+    // PRIORITY 1: BLUE - has BOTH Average Daily Views AND 4-Week Range
+    if (avgViewsMatch?.[1] && fourWeekMatch?.[1]) {
       cards.push({
         market: currentLocation || 'Market',
         type: 'avg-views',
         label: 'Avg Daily Views',
         data: [avgViewsMatch[1]],
         subtitle: '4-Wk Range',
-        subtitleData: fourWeekMatch?.[1] || '$2,000-$6,000',
+        subtitleData: fourWeekMatch[1],
         note: '*Rates vary by location.'
       });
     }
-    // PRIORITY 2: BLACK - has General Pricing with market size tiers
+    // PRIORITY 2: GREEN - has 4-Week Range only (no avg views)
+    else if (fourWeekMatch?.[1]) {
+      cards.push({
+        market: currentLocation || 'Market',
+        type: 'four-week-only',
+        label: '4-Week Range',
+        data: [fourWeekMatch[1]],
+        note: '*Rates vary by location.'
+      });
+    }
+    // PRIORITY 3: PURPLE - has Market Range
+    else if (marketRangeMatch?.[1]) {
+      cards.push({
+        market: currentLocation || 'Market',
+        type: 'market-range',
+        label: 'Market Range',
+        data: [marketRangeMatch[1].trim()],
+        subtitle: dbMarketName || undefined,  // Market name from DB (e.g., "Phx")
+        note: '*No city boards, but in market.'
+      });
+    }
+    // PRIORITY 4: BLACK - has General Pricing with market size tiers
     else if (hasGeneralPricing) {
       const priceRangePattern = /\$[\d,]+\s*-\s*\$[\d,]+/g;
       const generalPricingIndex = contextToUse.toLowerCase().indexOf('general pricing:');
@@ -262,7 +287,6 @@ export function PricingPanel({
       const tiers: { label: string; range: string }[] = [];
       
       if (generalRanges.length >= 3) {
-        // Use first 3 ranges for small/medium/large
         tiers.push({ label: tierLabels[0], range: generalRanges[0] });
         tiers.push({ label: tierLabels[1], range: generalRanges[1] });
         tiers.push({ label: tierLabels[2], range: generalRanges[2] });
@@ -270,7 +294,6 @@ export function PricingPanel({
         tiers.push({ label: tierLabels[0], range: generalRanges[0] });
         tiers.push({ label: tierLabels[2], range: generalRanges[1] });
       } else if (generalRanges.length === 1) {
-        // Single range - show as general range without tier labels
         tiers.push({ label: 'Price Range', range: generalRanges[0] });
       }
       
@@ -283,16 +306,7 @@ export function PricingPanel({
         note: '*No specific data. Use general range.'
       });
     }
-    // PRIORITY 3: PURPLE - has Market Range
-    else if (marketRangeMatch?.[1]) {
-      cards.push({
-        market: currentLocation || 'Market',
-        type: 'market-range',
-        label: 'Market Range',
-        data: [marketRangeMatch[1].trim()],
-        note: '*No city boards, but in market.'
-      });
-    }
+    // PRIORITY 5: No pricing cards - will fall back to details display
     
     return cards;
   };
@@ -302,8 +316,10 @@ export function PricingPanel({
   
   const getCardColors = (type: PricingCard['type']) => {
     switch (type) {
-      case 'market-range': return { primary: '#7c3aed', text: '#7c3aed' };
-      case 'avg-views': return { primary: '#2563eb', text: '#2563eb' };
+      case 'avg-views': return { primary: '#2563eb', text: '#2563eb' };        // Blue
+      case 'four-week-only': return { primary: '#16a34a', text: '#16a34a' };   // Green
+      case 'market-range': return { primary: '#7c3aed', text: '#7c3aed' };     // Purple
+      case 'general-range': return { primary: '#000000', text: '#000000' };    // Black
       default: return { primary: '#000000', text: '#000000' };
     }
   };
@@ -359,6 +375,16 @@ export function PricingPanel({
                       {card.label}
                     </div>
                     
+                    {/* For market-range: show market name from DB between header and price */}
+                    {card.type === 'market-range' && card.subtitle && (
+                      <div 
+                        className="text-center py-2 border-l-2 border-r-2 border-b-2 border-black font-bold text-xl bg-white"
+                        style={{ color: colors.text }}
+                      >
+                        {card.subtitle}
+                      </div>
+                    )}
+                    
                     {/* Render tiers for general-range type */}
                     {card.tiers && card.tiers.map((tier, tierIdx) => (
                       <div key={tierIdx}>
@@ -384,7 +410,8 @@ export function PricingPanel({
                       </div>
                     ))}
                     
-                    {card.subtitle && (
+                    {/* For avg-views type: show subtitle (4-Wk Range) AFTER the data */}
+                    {card.type === 'avg-views' && card.subtitle && (
                       <>
                         <div className="text-center text-xl py-2 border-l-2 border-r-2 border-black text-white font-bold mt-3" style={{ backgroundColor: colors.primary }}>
                           {card.subtitle}

--- a/components/sales-call/PricingPanel.tsx
+++ b/components/sales-call/PricingPanel.tsx
@@ -314,7 +314,7 @@ export function PricingPanel({
   return (
     <div 
       className="h-full flex flex-col transition-all duration-300"
-      style={{ maxWidth: activeTab === 'estimate' ? '400px' : '400px', width: '100%' }}
+      style={{ maxWidth: '400px', width: '100%' }}
     >
       <div className="bg-white rounded-xl p-4 h-full flex flex-col overflow-hidden">
         {/* Header Tabs */}
@@ -451,8 +451,8 @@ export function PricingPanel({
           )}
         </div>
 
-        {/* Nutshell Button */}
-        <div className="flex flex-col items-center gap-2 pt-3 border-t border-slate-200 mt-3 flex-shrink-0">
+        {/* Nutshell Button - pushed to bottom with mt-auto */}
+        <div className="flex flex-col items-center gap-2 pt-3 border-t border-slate-200 mt-auto flex-shrink-0">
           {nutshellStatus !== 'idle' && (
             <span className={`text-xs font-medium ${nutshellStatus === 'success' ? 'text-green-600' : 'text-red-600'}`}>{nutshellMessage}</span>
           )}

--- a/components/sales-call/formFields.tsx
+++ b/components/sales-call/formFields.tsx
@@ -468,7 +468,7 @@ export const DecisionMakerButtonGroup = memo(function DecisionMakerButtonGroup({
   }, [contactIndex, updateContactField, setConfirmedDecisionMaker]);
 
   return (
-    <div className={`flex gap-3 ${className}`}>
+    <div className={`flex gap-1 sm:gap-2 lg:gap-3 flex-wrap lg:flex-nowrap ${className}`}>
       {options.map((option) => {
         let bgClass = 'bg-red-100 border-black';
         if (confirmedValue === option.value) {
@@ -481,7 +481,7 @@ export const DecisionMakerButtonGroup = memo(function DecisionMakerButtonGroup({
           <button
             key={option.value}
             onClick={() => handleClick(option.value)}
-            className={`font-bold border-2 rounded transition-colors px-3.5 py-2 text-md ${bgClass}`}
+            className={`font-bold border-2 rounded transition-colors px-2 sm:px-2.5 lg:px-3.5 py-1 sm:py-1.5 lg:py-2 text-xs sm:text-sm lg:text-md whitespace-nowrap ${bgClass}`}
           >
             {option.label}
           </button>
@@ -515,9 +515,9 @@ export const BoardTypeButtonGroup = memo(function BoardTypeButtonGroup({
   });
 
   const options = [
-    { value: "Static", label: "Static" },
-    { value: "Digital", label: "Digital" },
-    { value: "Both", label: "Both" },
+    { value: "Static", label: "Static", short: "Sta" },
+    { value: "Digital", label: "Digital", short: "Dig" },
+    { value: "Both", label: "Both", short: "Bot" },
   ];
 
   const handleClick = useCallback((value: string) => {
@@ -526,7 +526,7 @@ export const BoardTypeButtonGroup = memo(function BoardTypeButtonGroup({
   }, [marketIndex, updateMarketField, setConfirmedBoardType]);
 
   return (
-    <div className={`flex gap-1.5 ${className}`}>
+    <div className={`flex gap-0.5 sm:gap-1 lg:gap-1.5 justify-center min-w-0 overflow-hidden ${className}`}>
       {options.map((option) => {
         let bgClass = 'bg-red-100 border-black';
         if (confirmedValue === option.value) {
@@ -539,9 +539,10 @@ export const BoardTypeButtonGroup = memo(function BoardTypeButtonGroup({
           <button
             key={option.value}
             onClick={() => handleClick(option.value)}
-            className={`font-bold border-2 rounded transition-colors px-2.5 py-1.5 text-md xl:text-sm flex-1 ${bgClass}`}
+            className={`font-bold border-2 rounded transition-colors px-1 sm:px-1.5 lg:px-3 py-0.5 sm:py-1 lg:py-1.5 text-xs sm:text-sm whitespace-nowrap flex-1 min-w-0 ${bgClass}`}
           >
-            {option.label}
+            <span className="sm:hidden">{option.short}</span>
+            <span className="hidden sm:inline">{option.label}</span>
           </button>
         );
       })}
@@ -605,7 +606,7 @@ export const DurationButtonGroup = memo(function DurationButtonGroup({
   }, [confirmedSelections, marketIndex, setConfirmedDuration, updateMarketField]);
 
   return (
-    <div className={`flex gap-2 ${className}`}>
+    <div className={`flex gap-0.5 sm:gap-1 lg:gap-1.5 max-w-full min-w-0 overflow-hidden ${className}`}>
       {options.map((option) => {
         const isConfirmed = confirmedSelections.includes(option.value);
         const isAISuggested = aiSuggestions.includes(option.value);
@@ -618,15 +619,15 @@ export const DurationButtonGroup = memo(function DurationButtonGroup({
         }
 
         return (
-          <div key={option.value} className="flex flex-col items-center">
+          <div key={option.value} className="flex flex-col items-center flex-1 min-w-0">
             <button
               onClick={() => handleClick(option.value)}
-              className={`font-bold border-2 rounded transition-colors px-2.5 py-1.5 text-sm text-nowrap lg:text-xs ${bgClass}`}
+              className={`font-bold border-2 rounded transition-colors px-1 py-0.5 sm:px-1.5 sm:py-1 lg:px-2 lg:py-1 text-nowrap text-[10px] sm:text-xs lg:text-sm w-full truncate ${bgClass}`}
             >
               {option.label}
             </button>
             {subtexts[option.value] && (
-              <span className="text-[10px] text-gray-500 font-normal">
+              <span className="text-[6px] sm:text-[8px] lg:text-[10px] text-gray-500 font-normal">
                 {subtexts[option.value]}
               </span>
             )}
@@ -657,11 +658,12 @@ export const SendOverButtonGroup = memo(function SendOverButtonGroup({
   const setConfirmedSendOver = useFormStore((s) => s.setConfirmedSendOver);
   const updateField = useFormStore((s) => s.updateField);
 
-  // ✅ Fix: Get raw value, handle array operations outside
+  // ✅ Fix: Get raw value, handle array operations outside (matching DurationButtonGroup pattern)
   const sendOverRaw = useFormStore((s) => contactIndex === 0 ? s.fields.sendOver : null);
   const aiSuggestions = (() => {
     if (contactIndex !== 0 || !sendOverRaw) return [];
-    return sendOverRaw.filter((s): s is "Avails" | "Panel Info" | "Planning Rates" => s !== undefined);
+    if (Array.isArray(sendOverRaw)) return sendOverRaw.flat() as string[];
+    return [sendOverRaw as string];
   })();
 
   const options = [
@@ -683,7 +685,7 @@ export const SendOverButtonGroup = memo(function SendOverButtonGroup({
   }, [confirmedSelections, contactIndex, setConfirmedSendOver, updateField]);
 
   return (
-    <div className={`flex gap-3 ${className}`}>
+    <div className={`flex gap-1 sm:gap-2 lg:gap-3 flex-wrap lg:flex-nowrap ${className}`}>
       {options.map((option) => {
         const isConfirmed = confirmedSelections.includes(option.value);
         const isAISuggested = aiSuggestions.includes(option.value as "Avails" | "Panel Info" | "Planning Rates");
@@ -699,7 +701,7 @@ export const SendOverButtonGroup = memo(function SendOverButtonGroup({
           <button
             key={option.value}
             onClick={() => handleClick(option.value)}
-            className={`font-bold border-2 rounded transition-colors px-3.5 py-2 text-md ${bgClass}`}
+            className={`font-bold border-2 rounded transition-colors px-2 sm:px-2.5 lg:px-3.5 py-1 sm:py-1.5 lg:py-2 text-xs sm:text-sm lg:text-md whitespace-nowrap ${bgClass}`}
           >
             {option.label}
           </button>
@@ -733,7 +735,7 @@ export const LeadTypeButtonGroup = memo(function LeadTypeButtonGroup({
   }, [updateField, setConfirmedLeadType]);
 
   return (
-    <div className={`flex gap-25 ${className}`}>
+    <div className={`flex flex-wrap gap-2 sm:gap-4 lg:gap-12 ${className}`}>
       {options.map((option) => {
         let bgClass = 'bg-red-100 border-black';
         if (confirmedValue === option.value) {
@@ -746,7 +748,7 @@ export const LeadTypeButtonGroup = memo(function LeadTypeButtonGroup({
           <button
             key={option.value}
             onClick={() => handleClick(option.value)}
-            className={`font-bold border-2 rounded transition-colors px-10 py-2.5 text-md ${bgClass}`}
+            className={`font-bold border-2 rounded transition-colors px-2 sm:px-3 lg:px-4 py-1 sm:py-1.5 lg:py-2 text-xs sm:text-sm lg:text-md whitespace-nowrap ${bgClass}`}
           >
             {option.label}
           </button>

--- a/stores/formStore.ts
+++ b/stores/formStore.ts
@@ -521,7 +521,7 @@ export const selectCurrentContact = (state: FormStore) => {
       phone: state.fields.phone ?? '',
       email: state.fields.email ?? '',
       decisionMaker: state.fields.decisionMaker ?? '',
-      sendOver: (state.fields.sendOver ?? []).filter((s): s is "Avails" | "Panel Info" | "Planning Rates" => s !== undefined),
+      sendOver: (Array.isArray(state.fields.sendOver) ? state.fields.sendOver : []).filter((s): s is "Avails" | "Panel Info" | "Planning Rates" => s !== undefined),
     };
   }
   return state.additionalContacts[state.activeContactIndex - 1] ?? {


### PR DESCRIPTION
Bug: SendOverButtonGroup crashed with TypeError: a.filter is not a function when AI extraction returned sendOver as a single string instead of an array.
Fix: Updated formFields.tsx to normalize sendOver values - if it's an array, flatten it; if it's a single string, wrap it in an array. This matches the existing pattern used by DurationButtonGroup for campaignLength.