### PR TITLE
updateV1

### DIFF
--- a/app/(auth)/admin/page.tsx
+++ b/app/(auth)/admin/page.tsx
@@ -2,6 +2,8 @@ import { getAllUsers, getUserCosts, getCurrentUser } from "@/lib/dal";
 import { getSession } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import AdminClient from "./admin-client";
+export const dynamic = 'force-dynamic'
+
 
 export default async function AdminPage() {
   // Verify user is authenticated and has admin role

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server'
+import { deleteSession } from '@/lib/auth'
+
+export async function POST() {
+  try {
+    await deleteSession()
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Logout error:', error)
+    return NextResponse.json({ error: 'Failed to logout' }, { status: 500 })
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -8,6 +8,8 @@ import {
 } from "@/components/ui/sidebar"
 import SalesCallTranscriber from "@/components/SalesCallTranscriber"
 import { getCurrentUser } from '@/lib/dal'
+export const dynamic = 'force-dynamic'
+
 
 function DashboardSkeleton() {
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,8 @@
 import { LoginForm } from "@/components/login-form"
 import Spline from "@splinetool/react-spline"
 
+
+
 export default function Home() {
   return (
     <div className="grid min-h-svh lg:grid-cols-2 bg-primary-foreground">

--- a/components/SalesCallTranscriber.tsx
+++ b/components/SalesCallTranscriber.tsx
@@ -12,6 +12,7 @@ import { LeadForm, PricingPanel, TranscriptView } from "@/components/sales-call"
 import type { TranscriptItem } from "@/types/sales-call";
 import { showSuccessToast, showErrorToast } from "@/lib/error-handling";
 import { useFormStore } from "@/stores/formStore";
+import { useAutoLogout } from "@/hooks/useAutoLogout"; 
 
 // Dynamic imports for heavy map components
 const GoogleMapPanel = dynamic(
@@ -25,6 +26,9 @@ const ArcGISMapPanel = dynamic(
 );
 
 export default function SalesCallTranscriber() {
+
+ useAutoLogout();
+
   // 🔍 Performance monitoring (only in development)
   if (process.env.NODE_ENV === 'development') {
     console.log('🔄 Re-render: SalesCallTranscriber');

--- a/hooks/useAutoLogout.ts
+++ b/hooks/useAutoLogout.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Auto-logout hook that logs users out at 8pm local time
+ * 
+ * Usage: Add to your main layout or dashboard layout:
+ * 
+ * function DashboardLayout({ children }) {
+ *   useAutoLogout();
+ *   return <>{children}</>;
+ * }
+ */
+
+const LOGOUT_HOUR = 20; // 8pm in 24-hour format
+
+export function useAutoLogout() {
+  const router = useRouter();
+  const hasLoggedOutRef = useRef(false);
+  const checkIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  const performLogout = useCallback(async () => {
+    // Prevent multiple logout attempts
+    if (hasLoggedOutRef.current) return;
+    hasLoggedOutRef.current = true;
+
+    console.log("🕗 8pm auto-logout triggered");
+
+    try {
+      // Call your logout API endpoint
+      await fetch("/api/auth/logout", { method: "POST" });
+    } catch (error) {
+      console.error("Logout API call failed:", error);
+    }
+
+    // Redirect to login page
+    router.push("/login?reason=auto-logout");
+  }, [router]);
+
+  const checkTime = useCallback(() => {
+    const now = new Date();
+    const currentHour = now.getHours();
+
+    // If it's 8pm (20:00) or later, trigger logout
+    if (currentHour >= LOGOUT_HOUR && !hasLoggedOutRef.current) {
+      performLogout();
+    }
+  }, [performLogout]);
+
+  useEffect(() => {
+    // Check immediately on mount
+    checkTime();
+
+    // Then check every minute
+    checkIntervalRef.current = setInterval(checkTime, 60 * 1000);
+
+    // Also check when tab becomes visible (in case user was away)
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        checkTime();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      if (checkIntervalRef.current) {
+        clearInterval(checkIntervalRef.current);
+      }
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [checkTime]);
+
+  // Reset the logout flag at midnight so users can log in the next day
+  useEffect(() => {
+    const checkMidnightReset = () => {
+      const now = new Date();
+      const currentHour = now.getHours();
+
+      // Reset flag between midnight and 5am (allowing for next day logins)
+      if (currentHour >= 0 && currentHour < 5) {
+        hasLoggedOutRef.current = false;
+      }
+    };
+
+    const midnightInterval = setInterval(checkMidnightReset, 60 * 60 * 1000); // Check every hour
+
+    return () => clearInterval(midnightInterval);
+  }, []);
+}

--- a/hooks/useWorkerStatus.tsx
+++ b/hooks/useWorkerStatus.tsx
@@ -11,6 +11,7 @@ interface WorkerStatusContextType {
   isSessionExpired: boolean;
   setStatus: (status: WorkerActivity) => Promise<void>;
   refresh: () => Promise<void>;
+  reconnect: () => void; // New: manual reconnect without page refresh
 }
 
 const WorkerStatusContext = createContext<WorkerStatusContextType | null>(null);
@@ -42,7 +43,8 @@ export function WorkerStatusProvider({ children }: WorkerStatusProviderProps) {
   const statusRef = useRef<WorkerActivity>("offline");
   const authFailedRef = useRef(false);
   const retryCountRef = useRef(0);
-  const MAX_RETRIES = 3;
+  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const MAX_RETRIES = 5; // Increased slightly to handle brief network blips
 
   /* ---------------------------------------------------- */
   /* Fetch current status                                 */
@@ -62,7 +64,7 @@ export function WorkerStatusProvider({ children }: WorkerStatusProviderProps) {
       if (res.status === 401) {
         authFailedRef.current = true;
         setIsSessionExpired(true);
-        setError("Session expired - please refresh the page");
+        setError("Session expired - please log in again");
         return;
       }
 
@@ -88,7 +90,7 @@ export function WorkerStatusProvider({ children }: WorkerStatusProviderProps) {
   const setStatus = useCallback(async (newStatus: WorkerActivity) => {
     // Don't allow status updates if session is expired
     if (authFailedRef.current) {
-      throw new Error("Session expired - please refresh the page");
+      throw new Error("Session expired - please log in again");
     }
 
     try {
@@ -107,8 +109,8 @@ export function WorkerStatusProvider({ children }: WorkerStatusProviderProps) {
       if (res.status === 401) {
         authFailedRef.current = true;
         setIsSessionExpired(true);
-        setError("Session expired - please refresh the page");
-        throw new Error("Session expired - please refresh the page");
+        setError("Session expired - please log in again");
+        throw new Error("Session expired - please log in again");
       }
 
       if (!res.ok) {
@@ -128,96 +130,142 @@ export function WorkerStatusProvider({ children }: WorkerStatusProviderProps) {
   }, []);
 
   /* ---------------------------------------------------- */
-  /* SSE connection for real-time status updates          */
+  /* SSE connection function (extracted for reuse)        */
   /* ---------------------------------------------------- */
-  useEffect(() => {
-    const connectSSE = () => {
-      // Don't reconnect if we know auth has failed
+  const connectSSE = useCallback(() => {
+    // Don't reconnect if we know auth has failed
+    if (authFailedRef.current) {
+      console.log("🚫 SSE reconnect skipped - session expired");
+      return;
+    }
+
+    // Clear any pending reconnect timeout
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+
+    // Close existing connection
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+
+    console.log("📡 SSE connecting...");
+    const eventSource = new EventSource("/api/taskrouter/worker-status-stream");
+    eventSourceRef.current = eventSource;
+
+    eventSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+
+        // Handle auth error from server - stop retrying
+        if (data.error === "unauthorized" || data.code === 401) {
+          console.error("❌ Session expired - stopping SSE reconnection");
+          authFailedRef.current = true;
+          setIsSessionExpired(true);
+          setError("Session expired - please log in again");
+          setIsLoading(false);
+          eventSource.close();
+          return;
+        }
+
+        if (data.error) {
+          console.error("❌ SSE error:", data.error);
+          setError(data.error);
+          return;
+        }
+
+        // Reset retry count on successful message
+        retryCountRef.current = 0;
+
+        const newStatus = data.status || "offline";
+        if (newStatus !== statusRef.current) {
+          setStatusState(newStatus);
+          statusRef.current = newStatus;
+          console.log("✅ Worker status updated via SSE:", newStatus);
+        }
+
+        setIsLoading(false);
+        setError(null);
+      } catch (err) {
+        console.error("❌ Failed to parse SSE message:", err);
+      }
+    };
+
+    eventSource.onerror = (err) => {
+      console.error("❌ SSE connection error:", err);
+      eventSource.close();
+      eventSourceRef.current = null;
+
+      // Don't retry if auth has failed
       if (authFailedRef.current) {
-        console.log("🚫 SSE reconnect skipped - session expired");
         return;
       }
 
-      if (eventSourceRef.current) {
-        eventSourceRef.current.close();
+      // Increment retry count
+      retryCountRef.current += 1;
+
+      // Stop retrying after MAX_RETRIES to prevent infinite loop
+      if (retryCountRef.current >= MAX_RETRIES) {
+        console.error("❌ Max SSE retries reached - stopping reconnection");
+        setError("Connection interrupted. Click 'Reconnect' to try again.");
+        setIsLoading(false);
+        return;
       }
 
-      const eventSource = new EventSource("/api/taskrouter/worker-status-stream");
-      eventSourceRef.current = eventSource;
-
-      eventSource.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data);
-
-          // Handle auth error from server - stop retrying
-          if (data.error === "unauthorized" || data.code === 401) {
-            console.error("❌ Session expired - stopping SSE reconnection");
-            authFailedRef.current = true;
-            setIsSessionExpired(true);
-            setError("Session expired - please refresh the page");
-            setIsLoading(false);
-            eventSource.close();
-            return;
-          }
-
-          if (data.error) {
-            console.error("❌ SSE error:", data.error);
-            setError(data.error);
-            return;
-          }
-
-          // Reset retry count on successful message
-          retryCountRef.current = 0;
-
-          const newStatus = data.status || "offline";
-          if (newStatus !== statusRef.current) {
-            setStatusState(newStatus);
-            statusRef.current = newStatus;
-            console.log("✅ Worker status updated via SSE:", newStatus);
-          }
-
-          setIsLoading(false);
-          setError(null);
-        } catch (err) {
-          console.error("❌ Failed to parse SSE message:", err);
-        }
-      };
-
-      eventSource.onerror = (err) => {
-        console.error("❌ SSE connection error:", err);
-        eventSource.close();
-
-        // Don't retry if auth has failed
-        if (authFailedRef.current) {
-          return;
-        }
-
-        // Increment retry count
-        retryCountRef.current += 1;
-
-        // Stop retrying after MAX_RETRIES to prevent infinite loop
-        if (retryCountRef.current >= MAX_RETRIES) {
-          console.error("❌ Max SSE retries reached - stopping reconnection");
-          setError("Connection lost - please refresh the page");
-          setIsLoading(false);
-          return;
-        }
-
-        // Reconnect after 5 seconds with exponential backoff
-        const backoffTime = Math.min(5000 * Math.pow(2, retryCountRef.current - 1), 30000);
-        console.log(`🔄 SSE reconnecting in ${backoffTime}ms (attempt ${retryCountRef.current}/${MAX_RETRIES})`);
-        setTimeout(connectSSE, backoffTime);
-      };
+      // Reconnect with exponential backoff
+      const backoffTime = Math.min(5000 * Math.pow(2, retryCountRef.current - 1), 30000);
+      console.log(`🔄 SSE reconnecting in ${backoffTime}ms (attempt ${retryCountRef.current}/${MAX_RETRIES})`);
+      reconnectTimeoutRef.current = setTimeout(connectSSE, backoffTime);
     };
+  }, []);
 
+  /* ---------------------------------------------------- */
+  /* Manual reconnect (resets everything and tries again) */
+  /* ---------------------------------------------------- */
+  const reconnect = useCallback(() => {
+    console.log("🔄 Manual reconnect triggered");
+    
+    // Reset all failure flags
+    retryCountRef.current = 0;
+    authFailedRef.current = false;
+    setIsSessionExpired(false);
+    setError(null);
+    setIsLoading(true);
+
+    // Clear any pending reconnect timeout
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+
+    // Close existing connection if any
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+
+    // Start fresh connection
+    connectSSE();
+  }, [connectSSE]);
+
+  /* ---------------------------------------------------- */
+  /* Initial SSE connection                               */
+  /* ---------------------------------------------------- */
+  useEffect(() => {
     connectSSE();
 
     return () => {
+      // Cleanup on unmount
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+      }
       if (eventSourceRef.current) {
         eventSourceRef.current.close();
       }
     };
-  }, []);
+  }, [connectSSE]);
 
   /* ---------------------------------------------------- */
   /* Auto-offline on tab close / refresh                  */
@@ -247,9 +295,8 @@ export function WorkerStatusProvider({ children }: WorkerStatusProviderProps) {
   }, []);
 
   /* ---------------------------------------------------- */
-  /* Initial load handled by SSE connection              */
+  /* Context value                                        */
   /* ---------------------------------------------------- */
-
   const value: WorkerStatusContextType = {
     status,
     isLoading,
@@ -257,6 +304,7 @@ export function WorkerStatusProvider({ children }: WorkerStatusProviderProps) {
     isSessionExpired,
     setStatus,
     refresh,
+    reconnect, // New: exposed for UI to use
   };
 
   return (

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -9,33 +9,43 @@ import { cache } from 'react'
 //JWT types
 interface JWTPayload {
   userId: string
+  email?: string
   [key: string]: string | number | boolean | null | undefined
 }
 
-// secret key for JWT signing ( in a real app, use env variables)
+// secret key for JWT signing (in a real app, use env variables)
 const JWT_SECRET = new TextEncoder().encode(
   process.env.JWT_SECRET || 'your-secret-key-min-32-chars-long'
 )
 
-// JWT experation
-const JWT_EXPIRATION = '2d' // 1 day
+// JWT expiration
+const JWT_EXPIRATION = '2d' // 2 days
 
-// token refresh threshold
+// token refresh threshold - refresh if token expires within this time
 const REFRESH_THRESHOLD = 24 * 60 * 60 // 24 hours in seconds
+
+// cookie max age in seconds
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 2 // 2 days
 
 // hash a password
 export async function hashPassword(password: string) {
   return hash(password, 10)
 }
+
 //verify password
 export async function verifyPassword(password: string, hashedPassword: string) {
   return compare(password, hashedPassword)
 }
+
 // create a new user
-export async function createUser(email: string, password: string, role: string = 'user', twilioPhoneNumber?: string) {
+export async function createUser(
+  email: string,
+  password: string,
+  role: string = 'user',
+  twilioPhoneNumber?: string
+) {
   const hashedPassword = await hashPassword(password)
   const id = nanoid()
-
   console.log(id)
 
   try {
@@ -48,7 +58,7 @@ export async function createUser(email: string, password: string, role: string =
     })
     return { id, email }
   } catch (error) {
-    console.error("error createing user:", error)
+    console.error('error creating user:', error)
     return null
   }
 }
@@ -68,7 +78,7 @@ export async function verifyJWT(token: string): Promise<JWTPayload | null> {
     const { payload } = await jose.jwtVerify(token, JWT_SECRET)
     return payload as JWTPayload
   } catch (error) {
-    console.error('JWT verifcation failed:', error)
+    console.error('JWT verification failed:', error)
     return null
   }
 }
@@ -91,6 +101,20 @@ export async function shouldRefreshToken(token: string): Promise<boolean> {
   }
 }
 
+// helper to set auth cookie
+async function setAuthCookie(token: string) {
+  const cookieStore = await cookies()
+  cookieStore.set({
+    name: 'auth_token',
+    value: token,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: COOKIE_MAX_AGE,
+    path: '/',
+    sameSite: 'lax',
+  })
+}
+
 // create a session using jwt
 export async function createSession(userId: string, email: string) {
   try {
@@ -98,16 +122,8 @@ export async function createSession(userId: string, email: string) {
     const token = await generateJWT({ userId, email })
 
     //store jwt in a cookie
-    const cookieStore = await cookies()
-    cookieStore.set({
-      name: 'auth_token',
-      value: token,
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      maxAge: 60 * 60 * 24 * 2, // 2 days
-      path: '/',
-      sameSite: 'lax'
-    })
+    await setAuthCookie(token)
+
     return true
   } catch (error) {
     console.error('Error creating session:', error)
@@ -115,15 +131,35 @@ export async function createSession(userId: string, email: string) {
   }
 }
 
-// get current session from jwt
+// get current session from jwt with auto-refresh
 export const getSession = cache(async () => {
   try {
     const cookieStore = await cookies()
     const token = cookieStore.get('auth_token')?.value
 
     if (!token) return null
+
     const payload = await verifyJWT(token)
-    return payload ? { userId: payload.userId, email: payload.email as string } : null
+    if (!payload) return null
+
+    // Auto-refresh token if it's getting close to expiration
+    // This keeps active users logged in indefinitely
+    try {
+      if (await shouldRefreshToken(token)) {
+        const newToken = await generateJWT({
+          userId: payload.userId,
+          email: payload.email as string,
+        })
+        await setAuthCookie(newToken)
+        console.log('🔄 Session token auto-refreshed for user:', payload.userId)
+      }
+    } catch (refreshError) {
+      // If refresh fails, still return the valid session
+      // The user will just need to login when the token eventually expires
+      console.error('Token refresh failed (non-fatal):', refreshError)
+    }
+
+    return { userId: payload.userId, email: payload.email as string }
   } catch (error) {
     if (
       error instanceof Error &&
@@ -132,6 +168,8 @@ export const getSession = cache(async () => {
       console.log('Cookies not available during prerendering, returning null session')
       return null
     }
+    console.error('Error getting session:', error)
+    return null
   }
 })
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -19,13 +19,13 @@ const JWT_SECRET = new TextEncoder().encode(
 )
 
 // JWT expiration
-const JWT_EXPIRATION = '2d' // 2 days
+const JWT_EXPIRATION = '4h' 
 
 // token refresh threshold - refresh if token expires within this time
-const REFRESH_THRESHOLD = 24 * 60 * 60 // 24 hours in seconds
+const REFRESH_THRESHOLD = 60 * 60 // 24 hours in seconds
 
 // cookie max age in seconds
-const COOKIE_MAX_AGE = 60 * 60 * 24 * 2 // 2 days
+const COOKIE_MAX_AGE = 60 * 60 * 4 // 2 days
 
 // hash a password
 export async function hashPassword(password: string) {

--- a/lib/sse-manager.ts
+++ b/lib/sse-manager.ts
@@ -11,6 +11,7 @@ interface UserConnection {
   controller: SSEController;
   encoder: TextEncoder;
   lastStatus: string | null;
+  createdAt: number;
 }
 
 class SSEManager {
@@ -28,6 +29,7 @@ class SSEManager {
       controller,
       encoder: new TextEncoder(),
       lastStatus: null,
+      createdAt: Date.now(),
     };
 
     this.connections.get(userId)!.add(connection);
@@ -52,27 +54,55 @@ class SSEManager {
   }
 
   /**
+   * Check if a controller is still usable
+   */
+  private isControllerValid(controller: SSEController): boolean {
+    try {
+      // Check if controller has desiredSize - if null, stream is closed
+      return controller.desiredSize !== null;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Broadcast status update to all connections for a user
    */
-  broadcast(userId: string, data: any) {
+  broadcast(userId: string, data: Record<string, unknown>) {
     const userConnections = this.connections.get(userId);
     if (!userConnections || userConnections.size === 0) {
       return;
     }
 
     const message = `data: ${JSON.stringify(data)}\n\n`;
+    const staleConnections: UserConnection[] = [];
+    let successCount = 0;
 
     for (const connection of userConnections) {
       try {
+        // Check if controller is still valid before trying to enqueue
+        if (!this.isControllerValid(connection.controller)) {
+          staleConnections.push(connection);
+          continue;
+        }
+
         connection.controller.enqueue(connection.encoder.encode(message));
-        connection.lastStatus = data.status;
+        connection.lastStatus = data.status as string;
+        successCount++;
       } catch (error) {
         console.error(`❌ Failed to send SSE message to user ${userId}:`, error);
-        this.removeConnection(userId, connection);
+        staleConnections.push(connection);
       }
     }
 
-    console.log(`📡 Broadcasted to ${userConnections.size} connection(s) for user ${userId}`);
+    // Clean up stale connections after iteration (avoid modifying set during iteration)
+    for (const staleConnection of staleConnections) {
+      this.removeConnection(userId, staleConnection);
+    }
+
+    if (successCount > 0) {
+      console.log(`📡 Broadcasted to ${successCount} connection(s) for user ${userId}`);
+    }
   }
 
   /**
@@ -90,7 +120,6 @@ class SSEManager {
     if (!userConnections || userConnections.size === 0) {
       return null;
     }
-
     return Array.from(userConnections)[0].lastStatus;
   }
 
@@ -100,6 +129,35 @@ class SSEManager {
   hasConnections(userId: string): boolean {
     const userConnections = this.connections.get(userId);
     return userConnections ? userConnections.size > 0 : false;
+  }
+
+  /**
+   * Clean up all stale connections across all users
+   * Can be called periodically if needed
+   */
+  cleanupStaleConnections() {
+    let totalCleaned = 0;
+
+    for (const [userId, userConnections] of this.connections) {
+      const staleConnections: UserConnection[] = [];
+
+      for (const connection of userConnections) {
+        if (!this.isControllerValid(connection.controller)) {
+          staleConnections.push(connection);
+        }
+      }
+
+      for (const staleConnection of staleConnections) {
+        this.removeConnection(userId, staleConnection);
+        totalCleaned++;
+      }
+    }
+
+    if (totalCleaned > 0) {
+      console.log(`🧹 Cleaned up ${totalCleaned} stale SSE connection(s)`);
+    }
+
+    return totalCleaned;
   }
 }
 


### PR DESCRIPTION
Problem
Constant 401 errors in Vercel logs caused by expired sessions triggering an infinite SSE reconnection loop. Secondary concern: reps staying logged in too long and potential form submission failures.

File 1: lib/auth.ts
Changes:

JWT_EXPIRATION: '2d' → '4h'
REFRESH_THRESHOLD: 24 hours → 1 hour
COOKIE_MAX_AGE: 2 days → 4 hours
Added auto-refresh logic in getSession()

Why: Sessions now expire after 4 hours of inactivity, but active users stay logged in because tokens auto-refresh during use.

File 2: app/api/taskrouter/worker-status-stream/route.ts
Changes: Returns auth errors as SSE-formatted messages instead of 401 JSON
Why: Allows the client to detect auth failures and stop retrying, instead of triggering an infinite reconnection loop.

File 3: hooks/useWorkerStatus.tsx
Changes:

Added authFailedRef to track auth failures
Added retry limit (max 3 attempts) with exponential backoff
Added isSessionExpired state for UI warnings
Adds a reconnect() function that resets everything and tries to connect again without requiring a page refresh.


Why: Stops infinite 401 retry loops and warns users before they submit forms with expired sessions.

File 4: lib/sse-manager.ts
Changes:

Fixed syntax errors (console.log missing parentheses)
Added isControllerValid() check before writing to streams
Stale connections removed after iteration, not during

Why: Eliminates "Controller is already closed" errors when broadcasting to disconnected clients.

File 5: hooks/useAutoLogout.ts (NEW)
What it does: Checks the user's local time every minute and logs them out at 8pm.
Why: Your boss wanted users logged out at end of day.

File 6: app/api/auth/logout/route.ts (NEW)
What it does: API endpoint that calls deleteSession()
Why: The useAutoLogout hook needs an API route to call via fetch().