### PR TITLE
reduce compute hours by cacheing

### DIFF
--- a/actions/auth.ts
+++ b/actions/auth.ts
@@ -87,7 +87,7 @@ export async function signIn(formData: FormData): Promise<ActionResponse> {
     }
 
     //create session
-    await createSession(user.id, user.email)
+    await createSession(user.id, user.email, user.role ?? 'user')
     return {
       success: true,
       message: 'Signed in successfully'

--- a/actions/user-actions.ts
+++ b/actions/user-actions.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { deleteUsersByIds, getCurrentUser, updateUserTwilioPhone } from "@/lib/dal";
+import { deleteUsersByIds, updateUserTwilioPhone } from "@/lib/dal";
 import { getSession } from "@/lib/auth";
 import { revalidatePath } from "next/cache";
 
@@ -15,9 +15,7 @@ export async function deleteUsers(ids: string[]) {
       };
     }
 
-    // Verify user has admin role
-    const currentUser = await getCurrentUser();
-    if (!currentUser || currentUser.role !== 'admin') {
+    if (session.role !== 'admin') {
       return {
         success: false,
         message: "Forbidden: Admin access required",
@@ -32,7 +30,7 @@ export async function deleteUsers(ids: string[]) {
     }
 
     // Prevent admin from deleting themselves
-    if (ids.includes(currentUser.id)) {
+    if (ids.includes(session.userId)) {
       return {
         success: false,
         message: "Cannot delete your own account",
@@ -61,8 +59,7 @@ export async function updateTwilioPhone(userId: string, twilioPhoneNumber: strin
       return { success: false, message: "Unauthorized" };
     }
 
-    const currentUser = await getCurrentUser();
-    if (!currentUser || currentUser.role !== 'admin') {
+    if (session.role !== 'admin') {
       return { success: false, message: "Admin access required" };
     }
 

--- a/app/(auth)/admin/page.tsx
+++ b/app/(auth)/admin/page.tsx
@@ -1,4 +1,4 @@
-import { getAllUsers, getUserCosts, getCurrentUser } from "@/lib/dal";
+import { getAllUsers, getUserCosts } from "@/lib/dal";
 import { getSession } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import AdminClient from "./admin-client";
@@ -12,8 +12,7 @@ export default async function AdminPage() {
     redirect('/login');
   }
 
-  const currentUser = await getCurrentUser();
-  if (!currentUser || currentUser.role !== 'admin') {
+  if (session.role !== 'admin') {
     redirect('/dashboard');
   }
 

--- a/app/api/billboard-data/process-chunk/route.ts
+++ b/app/api/billboard-data/process-chunk/route.ts
@@ -7,7 +7,6 @@ import OpenAI from 'openai';
 import { db } from '@/db';
 import { billboardLocations } from '@/db/schema';
 import { getSession } from '@/lib/auth';
-import { getCurrentUser } from '@/lib/dal';
 import { sql } from 'drizzle-orm';
 
 export const maxDuration = 300;
@@ -123,8 +122,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const currentUser = await getCurrentUser();
-    if (!currentUser || currentUser.role !== 'admin') {
+    if (session.role !== 'admin') {
       return NextResponse.json({ error: 'Forbidden: Admin access required' }, { status: 403 });
     }
 

--- a/app/api/billboard-data/start-process/route.ts
+++ b/app/api/billboard-data/start-process/route.ts
@@ -6,7 +6,6 @@ import { db } from '@/db';
 import { sql } from 'drizzle-orm';
 import { parse } from 'csv-parse/sync';
 import { getSession } from '@/lib/auth';
-import { getCurrentUser } from '@/lib/dal';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
@@ -19,8 +18,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const currentUser = await getCurrentUser();
-    if (!currentUser || currentUser.role !== 'admin') {
+    if (session.role !== 'admin') {
       return NextResponse.json({ error: 'Forbidden: Admin access required' }, { status: 403 });
     }
 

--- a/app/api/billboard-data/upload-blob/route.ts
+++ b/app/api/billboard-data/upload-blob/route.ts
@@ -2,7 +2,6 @@
 import { handleUpload, type HandleUploadBody } from '@vercel/blob/client';
 import { NextResponse } from 'next/server';
 import { getSession } from '@/lib/auth';
-import { getCurrentUser } from '@/lib/dal';
 
 export async function POST(request: Request): Promise<NextResponse> {
   console.log('📤 Upload-blob route hit');
@@ -13,8 +12,7 @@ export async function POST(request: Request): Promise<NextResponse> {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const currentUser = await getCurrentUser();
-  if (!currentUser || currentUser.role !== 'admin') {
+  if (session.role !== 'admin') {
     return NextResponse.json({ error: 'Forbidden: Admin access required' }, { status: 403 });
   }
 

--- a/app/api/billboard-pricing/route.ts
+++ b/app/api/billboard-pricing/route.ts
@@ -72,18 +72,6 @@ Transcript: ${transcript}`,
       dimensions: 512,
     });
     const embedding = embeddingResponse.data[0].embedding;
-
-    // ✅ First, let's check what we have in the database for this city/state
-    const debugResults = await db.execute(sql`
-      SELECT DISTINCT city, state
-      FROM billboard_locations
-      WHERE LOWER(city) LIKE LOWER(${'%' + city + '%'})
-         OR LOWER(state) LIKE LOWER(${'%' + state + '%'})
-      LIMIT 10
-    `);
-
-    console.log('🔍 DEBUG - Similar locations in database:', debugResults.rows);
-
     // ✅ STRICT HYBRID SEARCH: Require both city AND state to match
     const results = await db.execute(sql`
       SELECT 

--- a/app/api/passkey/auth-verify/route.ts
+++ b/app/api/passkey/auth-verify/route.ts
@@ -60,7 +60,7 @@ export async function POST(request: NextRequest) {
 
     // Get user info to create session
     const [userData] = await db
-      .select({ id: user.id, email: user.email })
+      .select({ id: user.id, email: user.email, role: user.role })
       .from(user)
       .where(eq(user.id, result.userId))
       .limit(1)
@@ -73,7 +73,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Create session (sets the auth cookie)
-    await createSession(userData.id, userData.email)
+    await createSession(userData.id, userData.email, userData.role ?? 'user')
 
     return NextResponse.json({
       verified: true,

--- a/app/api/taskrouter/worker-availability/route.ts
+++ b/app/api/taskrouter/worker-availability/route.ts
@@ -22,6 +22,114 @@ const PERIOD_DAYS = 28; // Twilio retains 30 days max; use 28 to stay safely wit
 
 const client = twilio(ACCOUNT_SID, AUTH_TOKEN);
 
+// In-memory cache: store result + timestamp, refresh once per day
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+let cachedResponse: { data: unknown; fetchedAt: number } | null = null;
+
+async function fetchAvailability() {
+  // Get all DB users to map emails → user IDs
+  const dbUsers = await db
+    .select({ id: user.id, email: user.email })
+    .from(user);
+
+  const emailToUserId: Record<string, string> = {};
+  for (const u of dbUsers) {
+    emailToUserId[u.email.toLowerCase()] = u.id;
+  }
+
+  // List all workers directly from TaskRouter (source of truth)
+  const twilioWorkers = await client.taskrouter.v1
+    .workspaces(WORKSPACE_SID)
+    .workers.list();
+
+  console.log(`📊 Found ${twilioWorkers.length} TaskRouter workers`);
+
+  // Use minutes param (28 days = 40320 minutes)
+  const periodMinutes = PERIOD_DAYS * 24 * 60;
+
+  // Fetch statistics for each worker in parallel
+  const results = await Promise.allSettled(
+    twilioWorkers.map(async (worker) => {
+      const stats = await client.taskrouter.v1
+        .workspaces(WORKSPACE_SID)
+        .workers(worker.sid)
+        .statistics()
+        .fetch({ minutes: periodMinutes });
+
+      const cumulative = stats.cumulative as Record<string, unknown>;
+
+      const activityDurations = cumulative?.activity_durations as
+        | Array<{ friendly_name: string; total: number }>
+        | undefined;
+
+      // Find the "Available" activity duration
+      const availableEntry = activityDurations?.find(
+        (entry) => entry.friendly_name.toLowerCase() === 'available'
+      );
+
+      const totalAvailableSeconds = availableEntry?.total ?? 0;
+      const totalHours =
+        Math.round((totalAvailableSeconds / 3600) * 10) / 10;
+      const avgDailyHours =
+        Math.round((totalAvailableSeconds / PERIOD_DAYS / 3600) * 10) / 10;
+
+      // Match worker to DB user by friendlyName (email)
+      const userId = emailToUserId[worker.friendlyName.toLowerCase()];
+
+      return {
+        userId,
+        workerEmail: worker.friendlyName,
+        workerSid: worker.sid,
+        avgDailyHours,
+        totalHours,
+      };
+    })
+  );
+
+  // Build the response
+  const availability: Record<
+    string,
+    { avgDailyHours: number; totalHours: number }
+  > = {};
+
+  const errors: string[] = [];
+
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      const { userId, avgDailyHours, totalHours } = result.value;
+      if (userId) {
+        availability[userId] = { avgDailyHours, totalHours };
+      }
+    } else {
+      const reason =
+        result.reason instanceof Error
+          ? result.reason.message
+          : String(result.reason);
+      console.error('❌ Worker stats fetch failed:', reason);
+      errors.push(reason);
+    }
+  }
+
+  console.log(
+    `📊 Returning availability for ${Object.keys(availability).length}/${twilioWorkers.length} workers`
+  );
+
+  return {
+    availability,
+    periodDays: PERIOD_DAYS,
+    _debug: {
+      twilioWorkersFound: twilioWorkers.length,
+      workers: twilioWorkers.map((w) => ({
+        name: w.friendlyName,
+        sid: w.sid,
+        matched: !!emailToUserId[w.friendlyName.toLowerCase()],
+      })),
+      fulfilled: Object.keys(availability).length,
+      errors,
+    },
+  };
+}
+
 export async function GET() {
   try {
     const session = await getSession();
@@ -33,107 +141,16 @@ export async function GET() {
       return Response.json({ error: 'Forbidden' }, { status: 403 });
     }
 
-    // Get all DB users to map emails → user IDs
-    const dbUsers = await db
-      .select({ id: user.id, email: user.email })
-      .from(user);
-
-    const emailToUserId: Record<string, string> = {};
-    for (const u of dbUsers) {
-      emailToUserId[u.email.toLowerCase()] = u.id;
+    // Return cached data if still fresh (within 24 hours)
+    if (cachedResponse && Date.now() - cachedResponse.fetchedAt < CACHE_TTL_MS) {
+      console.log('📊 Returning cached worker availability');
+      return Response.json(cachedResponse.data);
     }
 
-    // List all workers directly from TaskRouter (source of truth)
-    const twilioWorkers = await client.taskrouter.v1
-      .workspaces(WORKSPACE_SID)
-      .workers.list();
+    const data = await fetchAvailability();
+    cachedResponse = { data, fetchedAt: Date.now() };
 
-    console.log(`📊 Found ${twilioWorkers.length} TaskRouter workers`);
-
-    // Use minutes param (28 days = 40320 minutes)
-    const periodMinutes = PERIOD_DAYS * 24 * 60;
-
-    // Fetch statistics for each worker in parallel
-    const results = await Promise.allSettled(
-      twilioWorkers.map(async (worker) => {
-        const stats = await client.taskrouter.v1
-          .workspaces(WORKSPACE_SID)
-          .workers(worker.sid)
-          .statistics()
-          .fetch({ minutes: periodMinutes });
-
-        const cumulative = stats.cumulative as Record<string, unknown>;
-
-        const activityDurations = cumulative?.activity_durations as
-          | Array<{ friendly_name: string; total: number }>
-          | undefined;
-
-        // Find the "Available" activity duration
-        const availableEntry = activityDurations?.find(
-          (entry) => entry.friendly_name.toLowerCase() === 'available'
-        );
-
-        const totalAvailableSeconds = availableEntry?.total ?? 0;
-        const totalHours =
-          Math.round((totalAvailableSeconds / 3600) * 10) / 10;
-        const avgDailyHours =
-          Math.round((totalAvailableSeconds / PERIOD_DAYS / 3600) * 10) / 10;
-
-        // Match worker to DB user by friendlyName (email)
-        const userId = emailToUserId[worker.friendlyName.toLowerCase()];
-
-        return {
-          userId,
-          workerEmail: worker.friendlyName,
-          workerSid: worker.sid,
-          avgDailyHours,
-          totalHours,
-        };
-      })
-    );
-
-    // Build the response
-    const availability: Record<
-      string,
-      { avgDailyHours: number; totalHours: number }
-    > = {};
-
-    const errors: string[] = [];
-
-    for (const result of results) {
-      if (result.status === 'fulfilled') {
-        const { userId, avgDailyHours, totalHours } = result.value;
-        if (userId) {
-          availability[userId] = { avgDailyHours, totalHours };
-        }
-      } else {
-        const reason =
-          result.reason instanceof Error
-            ? result.reason.message
-            : String(result.reason);
-        console.error('❌ Worker stats fetch failed:', reason);
-        errors.push(reason);
-      }
-    }
-
-    console.log(
-      `📊 Returning availability for ${Object.keys(availability).length}/${twilioWorkers.length} workers`
-    );
-
-    return Response.json({
-      availability,
-      periodDays: PERIOD_DAYS,
-      _debug: {
-        twilioWorkersFound: twilioWorkers.length,
-        workers: twilioWorkers.map((w) => ({
-          name: w.friendlyName,
-          sid: w.sid,
-          matched: !!emailToUserId[w.friendlyName.toLowerCase()],
-        })),
-        fulfilled: Object.keys(availability).length,
-        errors,
-      },
-    });
+    return Response.json(data);
   } catch (error) {
     console.error('❌ Worker availability error:', error);
     return Response.json({ error: 'Internal error' }, { status: 500 });

--- a/app/api/taskrouter/worker-availability/route.ts
+++ b/app/api/taskrouter/worker-availability/route.ts
@@ -12,7 +12,7 @@
 import twilio from 'twilio';
 import { db } from '@/db';
 import { user } from '@/db/schema';
-import { getCurrentUser } from '@/lib/dal';
+import { getSession } from '@/lib/auth';
 
 const ACCOUNT_SID = process.env.TWILIO_ACCOUNT_SID!;
 const AUTH_TOKEN = process.env.TWILIO_AUTH_TOKEN!;
@@ -24,12 +24,12 @@ const client = twilio(ACCOUNT_SID, AUTH_TOKEN);
 
 export async function GET() {
   try {
-    const currentUser = await getCurrentUser();
-    if (!currentUser) {
+    const session = await getSession();
+    if (!session) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    if (currentUser.role !== 'admin') {
+    if (session.role !== 'admin') {
       return Response.json({ error: 'Forbidden' }, { status: 403 });
     }
 

--- a/app/api/taskrouter/worker-status/route.ts
+++ b/app/api/taskrouter/worker-status/route.ts
@@ -45,10 +45,17 @@ export async function GET() {
       return Response.json({ error: 'User not found' }, { status: 404 });
     }
 
-    return Response.json({
-      status: currentUser.workerActivity || 'offline',
-      hasWorker: !!currentUser.taskRouterWorkerSid,
-    });
+    return Response.json(
+      {
+        status: currentUser.workerActivity || 'offline',
+        hasWorker: !!currentUser.taskRouterWorkerSid,
+      },
+      {
+        headers: {
+          'Cache-Control': 'private, max-age=5, stale-while-revalidate=10',
+        },
+      }
+    );
   } catch (error) {
     console.error('❌ Worker status GET error:', error);
     return Response.json({ error: 'Internal error' }, { status: 500 });

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -7,7 +7,7 @@ import {
   SidebarProvider,
 } from "@/components/ui/sidebar"
 import SalesCallTranscriber from "@/components/SalesCallTranscriber"
-import { getCurrentUser } from '@/lib/dal'
+import { getSession } from '@/lib/auth'
 export const dynamic = 'force-dynamic'
 
 
@@ -31,9 +31,9 @@ function DashboardSkeleton() {
 }
 
 export default async function Page() {
-  const currentUser = await getCurrentUser()
+  const session = await getSession()
   
-  if (!currentUser) {
+  if (!session) {
     redirect('/login')
   }
 
@@ -50,10 +50,10 @@ export default async function Page() {
       <AppSidebar
         variant="inset"
         user={{
-          name: currentUser.email.split('@')[0],
-          email: currentUser.email,
+          name: session.email.split('@')[0],
+          email: session.email,
           avatar: "",
-          role: currentUser.role ?? undefined
+          role: session.role ?? undefined
         }}
       />
       <SidebarInset className="flex flex-col h-dvh min-h-0 overflow-hidden bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50">

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -122,10 +122,10 @@ async function setAuthCookie(token: string) {
 }
 
 // create a session using jwt
-export async function createSession(userId: string, email: string) {
+export async function createSession(userId: string, email: string, role: string = 'user') {
   try {
     //create jwt with user data
-    const token = await generateJWT({ userId, email })
+    const token = await generateJWT({ userId, email, role })
 
     //store jwt in a cookie
     await setAuthCookie(token)
@@ -151,7 +151,7 @@ export const getSessionWithoutRefresh = cache(async () => {
     const payload = await verifyJWT(token)
     if (!payload) return null
 
-    return { userId: payload.userId, email: payload.email as string }
+    return { userId: payload.userId, email: payload.email as string, role: (payload.role as string) || 'user' }
   } catch (error) {
     if (
       error instanceof Error &&
@@ -187,6 +187,7 @@ export const getSession = cache(async () => {
         const newToken = await generateJWT({
           userId: payload.userId,
           email: payload.email as string,
+          role: (payload.role as string) || 'user',
         })
         await setAuthCookie(newToken)
         console.log('🔄 Session token auto-refreshed for user:', payload.userId)
@@ -197,7 +198,7 @@ export const getSession = cache(async () => {
       console.error('Token refresh failed (non-fatal):', refreshError)
     }
 
-    return { userId: payload.userId, email: payload.email as string }
+    return { userId: payload.userId, email: payload.email as string, role: (payload.role as string) || 'user' }
   } catch (error) {
     if (
       error instanceof Error &&


### PR DESCRIPTION
 Main optimizations:

  1. Role cached in JWT session (lib/auth.ts):
    - createSession() now stores role in JWT
    - getSession() returns role directly from token
    - Eliminates DB queries for role checks
  2. Eliminated getCurrentUser() calls across codebase:
    - actions/user-actions.ts - Uses session.role instead of DB query
    - app/(auth)/admin/page.tsx - Same pattern
    - All /api/billboard-data/* routes - Same pattern
    - app/api/taskrouter/worker-availability/route.ts - Switched to getSession()
    - app/dashboard/page.tsx - Uses session data directly
  3. Removed debug query (app/api/billboard-pricing/route.ts):
    - Deleted unnecessary SELECT DISTINCT city, state query
  4. Added HTTP caching (app/api/taskrouter/worker-status/route.ts):
    - 5s cache with 10s stale-while-revalidate

  Impact:
  - Before: Every admin/role check = DB query
  - After: Role retrieved from JWT (no DB hit)
  - Substantial reduction in DB connections/compute time